### PR TITLE
feat: Add CBZ file viewer

### DIFF
--- a/ipcRegistry.cjs
+++ b/ipcRegistry.cjs
@@ -103,6 +103,12 @@ const ipcDataRegistry = {
         },
         requiresResponse: true,
         returnType: "MangaUpdatesSearchSeriesResultEntry[]"
+    },
+    'open-cbz-if-exists': {
+        log: true,
+        name: 'openCbzIfExists',
+        requiresResponse: true,
+        returnType: "boolean"
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "axios": "^1.11.0",
     "levenshtein-edit-distance": "^3.0.1",
     "lodash": "^4.17.21",
+    "jszip": "^3.10.1",
     "lowdb": "^7.0.1",
     "node-json-db": "^2.3.1",
     "rater-js": "^1.0.1",

--- a/renderer.js
+++ b/renderer.js
@@ -153,19 +153,22 @@ window.addEventListener('DOMContentLoaded', async () => {
 
         colDiv.onclick =
           /**
-           * Callback for search ID button click.
+           * Callback for column click. Tries to open CBZ viewer first,
+           * otherwise opens the details modal.
            * @param {PointerEvent} ev
            */
-          (ev) => {
-            navigator.clipboard.writeText(record.key)
-              .then(() => {
-                // Optionally, show a confirmation (e.g., toast or alert)
-                // alert('Copied to clipboard!');
-                openModal(ev, record);
-              })
-              .catch(err => {
-                alert('Failed to copy: ' + err);
-              });
+          async (ev) => {
+            const viewerOpened = await window.api.openCbzIfExists(record);
+            if (!viewerOpened) {
+              // Fallback to original behavior if no CBZ was opened
+              navigator.clipboard.writeText(record.key)
+                .then(() => {
+                  openModal(ev, record);
+                })
+                .catch(err => {
+                  alert('Failed to copy: ' + err);
+                });
+            }
           };
 
         colDiv.className = 'column';

--- a/viewer-preload.cjs
+++ b/viewer-preload.cjs
@@ -1,0 +1,7 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+    onReceiveCbzImages: (callback) => ipcRenderer.on('receive-cbz-images', callback)
+});

--- a/viewer.css
+++ b/viewer.css
@@ -1,0 +1,56 @@
+body, html {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    background-color: #2c2c2c;
+    color: #f1f1f1;
+    font-family: sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
+
+.viewer-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+.image-container {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    max-width: 100%;
+    max-height: 90vh; /* Limit image height to 90% of viewport height */
+}
+
+#page-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.controls {
+    padding: 10px;
+    background-color: #1a1a1a;
+    width: 100%;
+    text-align: center;
+    box-sizing: border-box;
+    position: fixed;
+    bottom: 0;
+}
+
+button {
+    padding: 8px 16px;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+#page-counter {
+    margin: 0 20px;
+}

--- a/viewer.html
+++ b/viewer.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CBZ Viewer</title>
+    <link rel="stylesheet" href="viewer.css">
+</head>
+<body>
+    <div class="viewer-container">
+        <div class="image-container">
+            <img id="page-image" src="" alt="Manga Page">
+        </div>
+        <div class="controls">
+            <button id="prev-button">Previous</button>
+            <span id="page-counter">Page 0 / 0</span>
+            <button id="next-button">Next</button>
+        </div>
+    </div>
+    <script src="viewer.js"></script>
+</body>
+</html>

--- a/viewer.js
+++ b/viewer.js
@@ -1,0 +1,50 @@
+'use strict';
+
+window.addEventListener('DOMContentLoaded', () => {
+    const pageImage = document.getElementById('page-image');
+    const pageCounter = document.getElementById('page-counter');
+    const prevButton = document.getElementById('prev-button');
+    const nextButton = document.getElementById('next-button');
+
+    let images = [];
+    let currentPage = 0;
+
+    // Use the exposed API from the preload script to receive image data
+    window.electronAPI.onReceiveCbzImages((event, image_data) => {
+        images = image_data;
+        currentPage = 0;
+        updateViewer();
+    });
+
+    function updateViewer() {
+        if (images.length === 0) {
+            pageImage.src = '';
+            pageCounter.textContent = 'No images found';
+            prevButton.disabled = true;
+            nextButton.disabled = true;
+            return;
+        }
+
+        pageImage.src = images[currentPage];
+        pageCounter.textContent = `Page ${currentPage + 1} / ${images.length}`;
+        prevButton.disabled = currentPage === 0;
+        nextButton.disabled = currentPage >= images.length - 1;
+    }
+
+    prevButton.addEventListener('click', () => {
+        if (currentPage > 0) {
+            currentPage--;
+            updateViewer();
+        }
+    });
+
+    nextButton.addEventListener('click', () => {
+        if (currentPage < images.length - 1) {
+            currentPage++;
+            updateViewer();
+        }
+    });
+
+    // Initial state
+    updateViewer();
+});


### PR DESCRIPTION
This commit introduces a new feature that allows users to view `.cbz` comic book archives.

- Adds `jszip` as a dependency to handle `.cbz` (zip) files.
- Implements a new IPC handler (`open-cbz-if-exists`) in the main process. This handler checks for the existence of a `.cbz` file, reads it, extracts the images in natural sort order, and opens a new viewer window.
- Creates a new set of frontend files (`viewer.html`, `viewer.css`, `viewer.js`, `viewer-preload.cjs`) for the viewer UI and logic.
- Modifies the main window's renderer script (`renderer.js`) to call the new IPC handler when a manga record is clicked. If no `.cbz` file is found, it falls back to the original behavior.