### PR TITLE
feat: Add chapter navigation to CBZ viewer

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -47,8 +47,21 @@ declare global {
       toggleDevTools: () => void;
       openCbzViewer: (record: mangaHakuneko) => IpcApiResponse<boolean>;
     },
-    viewerAPI:{
-      onReceiveCbzImages: (callback: (event: Electron.IpcRendererEvent, images: string[]) => void) => () => void;
+    viewerAPI: {
+      getInitialChapter: () => Promise<void>;
+      getChapter: (chapterIndex: number) => Promise<void>;
+      onInitialChapterData: (callback: (data: {
+          images: string[];
+          chapter: string;
+          chapterList: string[];
+          currentIndex: number;
+      }) => void) => () => void;
+      onChapterLoaded: (callback: (data: {
+          images: string[];
+          chapter: string;
+          chapterList: string[];
+          currentIndex: number;
+      }) => void) => () => void;
     }
   }
 

--- a/viewer-preload.cjs
+++ b/viewer-preload.cjs
@@ -5,12 +5,24 @@ const { contextBridge, ipcRenderer } = require('electron');
 /** @type {IpcApi} */
 const api = {};
 
-/** @type {(callback: IpcCallback) => () => void} */
-api[`onReceiveCbzImages`] = (callback) => {
-    /** @type {(event: unknown, ...args: IpcApiArgs) => void} */
-    const listener = (...args) => callback(...args);
-    ipcRenderer.on(`receive-cbz-images`, listener);
-    return () => ipcRenderer.removeListener(`receive-cbz-images`, listener);
+/** @type {() => Promise<void>} */
+api.getInitialChapter = () => ipcRenderer.invoke('get-initial-chapter');
+
+/** @type {(chapterIndex: number) => Promise<void>} */
+api.getChapter = (chapterIndex) => ipcRenderer.invoke('get-chapter', { chapterIndex });
+
+/** @type {(callback: (data: { images: string[]; chapter: string; chapterList: string[]; currentIndex: number; }) => void) => () => void} */
+api.onInitialChapterData = (callback) => {
+    const listener = (event, ...args) => callback(...args);
+    ipcRenderer.on('initial-chapter-data', listener);
+    return () => ipcRenderer.removeListener('initial-chapter-data', listener);
+};
+
+/** @type {(callback: (data: { images: string[]; chapter: string; chapterList: string[]; currentIndex: number; }) => void) => () => void} */
+api.onChapterLoaded = (callback) => {
+    const listener = (event, ...args) => callback(...args);
+    ipcRenderer.on('chapter-loaded', listener);
+    return () => ipcRenderer.removeListener('chapter-loaded', listener);
 };
 
 contextBridge.exposeInMainWorld('viewerAPI', api);

--- a/viewer.html
+++ b/viewer.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="viewer.css">
 </head>
 <body>
+    <div id="navigation-bar">
+        <button id="prev-chapter">&lt;</button>
+        <span id="chapter-info"></span>
+        <button id="next-chapter">&gt;</button>
+    </div>
     <div id="image-container">
         <!-- Images will be dynamically inserted here -->
     </div>

--- a/viewer.js
+++ b/viewer.js
@@ -1,23 +1,63 @@
 'use strict';
 
 window.addEventListener('DOMContentLoaded', () => {
-    const imageContainer = /** @type {HTMLDivElement} */ (document.getElementById('image-container'));
+    const imageContainer = document.getElementById('image-container');
+    const prevBtn = document.getElementById('prev-chapter');
+    const nextBtn = document.getElementById('next-chapter');
+    const chapterInfo = document.getElementById('chapter-info');
 
-    window.viewerAPI.onReceiveCbzImages((event, images) => {
-        // Clear any existing images
+    let chapterList = [];
+    let currentIndex = -1;
+
+    function render(data) {
+        // Clear existing images
         imageContainer.innerHTML = '';
 
-        if (!images || images.length === 0) {
+        if (!data.images || data.images.length === 0) {
             imageContainer.textContent = 'No images found.';
             return;
         }
 
         // Create and append an img element for each image
-        images.forEach(imageSrc => {
+        data.images.forEach(imageSrc => {
             const img = document.createElement('img');
             img.src = imageSrc;
             img.alt = 'Manga Page';
             imageContainer.appendChild(img);
         });
+
+        // Update state
+        chapterList = data.chapterList;
+        currentIndex = data.currentIndex;
+
+        // Update chapter info
+        chapterInfo.textContent = `${data.chapter} (${currentIndex + 1}/${chapterList.length})`;
+
+        // Update button states
+        prevBtn.disabled = currentIndex === 0;
+        nextBtn.disabled = currentIndex === chapterList.length - 1;
+    }
+
+    window.viewerAPI.onInitialChapterData((data) => {
+        render(data);
     });
+
+    window.viewerAPI.onChapterLoaded((data) => {
+        render(data);
+    });
+
+    prevBtn.addEventListener('click', () => {
+        if (currentIndex > 0) {
+            window.viewerAPI.getChapter(currentIndex - 1);
+        }
+    });
+
+    nextBtn.addEventListener('click', () => {
+        if (currentIndex < chapterList.length - 1) {
+            window.viewerAPI.getChapter(currentIndex + 1);
+        }
+    });
+
+    // Request the initial chapter
+    window.viewerAPI.getInitialChapter();
 });


### PR DESCRIPTION
- Refactored the CBZ viewer logic to separate window creation from chapter loading.
- Implemented chapter navigation with previous and next buttons.
- Added logic to select an initial chapter based on a predefined priority.
- The previous button is disabled on the first chapter, and the next button is disabled on the last chapter.
- Restored the type-safe structure of the viewer preload script.