### PR TITLE
feat: Add chapter list panel to viewer

### DIFF
--- a/viewer.css
+++ b/viewer.css
@@ -91,3 +91,46 @@ html, body {
     font-weight: bold;
     font-family: sans-serif;
 }
+
+#chapter-list-container {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    font-family: sans-serif;
+    transition: all 0.3s ease-in-out;
+    max-height: 40px;
+    overflow: hidden;
+    border-top-right-radius: 4px;
+}
+
+#chapter-list-container:hover {
+    max-height: 50vh;
+}
+
+#chapter-list-handle {
+    padding: 10px;
+    cursor: pointer;
+    background-color: rgba(0, 0, 0, 0.7);
+    height: 20px;
+}
+
+#chapter-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    max-height: calc(50vh - 40px);
+}
+
+#chapter-list li {
+    padding: 10px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#chapter-list li:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+}

--- a/viewer.html
+++ b/viewer.html
@@ -19,6 +19,10 @@
         <!-- Images will be dynamically inserted here -->
     </div>
     <div id="image-container-bottom" class="container-show">Bottom</div>
+    <div id="chapter-list-container">
+        <div id="chapter-list-handle">Chapters</div>
+        <ul id="chapter-list"></ul>
+    </div>
     <script src="viewer.js"></script>
 </body>
 </html>

--- a/viewer.js
+++ b/viewer.js
@@ -6,6 +6,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const nextBtn = /** @type {HTMLButtonElement} */ (document.getElementById('next-chapter'));
     const chapterInfo = /** @type {HTMLSpanElement} */ (document.getElementById('chapter-info'));
     const navigationBar = /** @type {HTMLDivElement} */ (document.getElementById('navigation-bar'));
+    const chapterListContainer = /** @type {HTMLDivElement} */ (document.getElementById('chapter-list-container'));
+    const chapterListElement = /** @type {HTMLUListElement} */ (document.getElementById('chapter-list'));
 
     let chapterList = [];
     let currentIndex = -1;
@@ -47,6 +49,31 @@ window.addEventListener('DOMContentLoaded', () => {
         // Update button states
         prevBtn.disabled = currentIndex === 0;
         nextBtn.disabled = currentIndex === chapterList.length - 1;
+
+        renderChapterList();
+    }
+
+    /**
+     * Renders the chapter list in the chapter list container.
+     */
+    function renderChapterList() {
+        chapterListElement.innerHTML = '';
+        chapterList.forEach((chapter, index) => {
+            const li = document.createElement('li');
+            li.textContent = chapter;
+            li.addEventListener('click', () => {
+                if (index !== currentIndex) {
+                    // Clear existing images
+                    imageContainer.innerHTML = '';
+                    imageContainer.scrollTop = 0;
+
+                    prevBtn.disabled = true;
+                    nextBtn.disabled = true;
+                    window.viewerAPI.getChapter(index);
+                }
+            });
+            chapterListElement.appendChild(li);
+        });
     }
 
     window.viewerAPI.onInitialChapterData((data) => {


### PR DESCRIPTION
This commit introduces a new chapter list panel to the manga viewer.

The new panel is located in the bottom-left corner of the screen and is initially collapsed to the height of the navigation bar. When the user hovers over the panel, it expands to show a scrollable list of all chapters for the current manga.

The chapter list is populated dynamically. Clicking on a chapter in the list will load that chapter using the existing application logic. The panel is styled to match the existing UI elements.