### PR TITLE
feat: Add zoom option to the navigation bar

### DIFF
--- a/viewer.css
+++ b/viewer.css
@@ -17,7 +17,7 @@ html, body {
 }
 
 #image-container img {
-    max-width: 100%;
+    width: 100%;
     height: auto;
     display: block; /* Remove extra space below images */
 }

--- a/viewer.html
+++ b/viewer.html
@@ -12,6 +12,10 @@
         &nbsp;
         <button id="next-chapter">&gt;</button>
         &nbsp;&nbsp;
+        <button id="zoom-out">-</button>
+        &nbsp;
+        <button id="zoom-in">+</button>
+        &nbsp;&nbsp;
         <span id="chapter-info"></span>
     </div>
     <div id="image-container">

--- a/viewer.js
+++ b/viewer.js
@@ -4,6 +4,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const imageContainer = /** @type {HTMLDivElement} */ (document.getElementById('image-container'));
     const prevBtn = /** @type {HTMLButtonElement} */ (document.getElementById('prev-chapter'));
     const nextBtn = /** @type {HTMLButtonElement} */ (document.getElementById('next-chapter'));
+    const zoomInBtn = /** @type {HTMLButtonElement} */ (document.getElementById('zoom-in'));
+    const zoomOutBtn = /** @type {HTMLButtonElement} */ (document.getElementById('zoom-out'));
     const chapterInfo = /** @type {HTMLSpanElement} */ (document.getElementById('chapter-info'));
     const chapterListElement = /** @type {HTMLUListElement} */ (document.getElementById('chapter-list'));
 
@@ -12,6 +14,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     /** @type {number} */
     let currentIndex = -1;
+    let zoom = 100;
 
     /**
      * Renders the chapter data in the viewer.
@@ -37,6 +40,7 @@ window.addEventListener('DOMContentLoaded', () => {
             const img = document.createElement('img');
             img.src = imageSrc;
             img.alt = 'Manga Page';
+            img.style.width = `${zoom}%`;
             imageContainer.appendChild(img);
         });
 
@@ -122,6 +126,28 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // Next Chapter Button event listeners
     nextBtn.addEventListener('click', nextChapter);
+
+    /**
+     * Updates the zoom level of the images.
+     * @param {number} newZoom - The new zoom level.
+     */
+    function updateZoom(newZoom) {
+        zoom = Math.max(70, Math.min(130, newZoom)); // Clamp zoom between 70 and 130
+        const images = imageContainer.querySelectorAll('img');
+        images.forEach(img => {
+            img.style.width = `${zoom}%`;
+        });
+    }
+
+    // Zoom In Button event listener
+    zoomInBtn.addEventListener('click', () => {
+        updateZoom(zoom + 5);
+    });
+
+    // Zoom Out Button event listener
+    zoomOutBtn.addEventListener('click', () => {
+        updateZoom(zoom - 5);
+    });
 
     // Keyboard navigation
     document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
This commit adds a zoom option to the image viewer's navigation bar, allowing users to zoom in and out of the images.

The following changes were made:
- Added "Zoom In" and "Zoom Out" buttons to `viewer.html`.
- Implemented the zoom functionality in `viewer.js`, including:
  - A `zoom` variable to track the current zoom level.
  - An `updateZoom` function to apply the zoom level to the images.
  - Event listeners for the zoom buttons.
- Modified `viewer.css` to set the initial image width to 100%.

The zoom level changes in 5% increments and is clamped between 70% and 130%.