### PR TITLE
feat: Add zoom option with pixel-locking and reset

### DIFF
--- a/viewer.css
+++ b/viewer.css
@@ -17,7 +17,7 @@ html, body {
 }
 
 #image-container img {
-    max-width: 100%;
+    width: 100%;
     height: auto;
     display: block; /* Remove extra space below images */
 }

--- a/viewer.html
+++ b/viewer.html
@@ -12,6 +12,12 @@
         &nbsp;
         <button id="next-chapter">&gt;</button>
         &nbsp;&nbsp;
+        <button id="zoom-out">-</button>
+        &nbsp;
+        <button id="zoom-reset">o</button>
+        &nbsp;
+        <button id="zoom-in">+</button>
+        &nbsp;&nbsp;
         <span id="chapter-info"></span>
     </div>
     <div id="image-container">

--- a/viewer.js
+++ b/viewer.js
@@ -4,6 +4,9 @@ window.addEventListener('DOMContentLoaded', () => {
     const imageContainer = /** @type {HTMLDivElement} */ (document.getElementById('image-container'));
     const prevBtn = /** @type {HTMLButtonElement} */ (document.getElementById('prev-chapter'));
     const nextBtn = /** @type {HTMLButtonElement} */ (document.getElementById('next-chapter'));
+    const zoomInBtn = /** @type {HTMLButtonElement} */ (document.getElementById('zoom-in'));
+    const zoomOutBtn = /** @type {HTMLButtonElement} */ (document.getElementById('zoom-out'));
+    const zoomResetBtn = /** @type {HTMLButtonElement} */ (document.getElementById('zoom-reset'));
     const chapterInfo = /** @type {HTMLSpanElement} */ (document.getElementById('chapter-info'));
     const chapterListElement = /** @type {HTMLUListElement} */ (document.getElementById('chapter-list'));
 
@@ -12,6 +15,48 @@ window.addEventListener('DOMContentLoaded', () => {
 
     /** @type {number} */
     let currentIndex = -1;
+    let zoom = 100;
+
+    /**
+     * Applies the current zoom level to a single image.
+     * @param {HTMLImageElement} img
+     */
+    function applyZoomToImage(img) {
+        if (zoom === 100) {
+            // Reset to default responsive behavior
+            img.style.width = '100%';
+            img.style.maxWidth = '100%';
+            delete img.dataset.baseWidth;
+        } else {
+            // If we need a base width (for pixel-based zooming) and don't have one, get it.
+            // This happens on the first zoom away from 100%.
+            if (!img.dataset.baseWidth) {
+                img.dataset.baseWidth = img.clientWidth;
+            }
+
+            const baseWidth = parseFloat(img.dataset.baseWidth);
+            if (baseWidth > 0) { // Ensure image was loaded and has a width
+                const newPixelWidth = baseWidth * (zoom / 100);
+                img.style.width = `${newPixelWidth}px`;
+                img.style.maxWidth = 'none'; // Allow image to exceed container width
+            }
+        }
+    }
+
+    /**
+     * Updates the zoom level for all images.
+     * @param {number} newZoom - The new zoom level.
+     */
+    function updateZoom(newZoom) {
+        zoom = Math.max(70, Math.min(130, newZoom)); // Clamp zoom
+        const images = imageContainer.querySelectorAll('img');
+        images.forEach(img => {
+            // Ensure the image is loaded before trying to get its width
+            if (img.complete) {
+                applyZoomToImage(img);
+            }
+        });
+    }
 
     /**
      * Renders the chapter data in the viewer.
@@ -37,6 +82,16 @@ window.addEventListener('DOMContentLoaded', () => {
             const img = document.createElement('img');
             img.src = imageSrc;
             img.alt = 'Manga Page';
+            // Set initial width to 100% so it fills the container before any zooming.
+            img.style.width = '100%';
+            img.style.maxWidth = '100%';
+
+            img.onload = () => {
+                // Apply the current zoom state to the new image once it's loaded.
+                // This is crucial for when chapters are changed while zoomed in.
+                applyZoomToImage(img);
+            };
+
             imageContainer.appendChild(img);
         });
 
@@ -122,6 +177,21 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // Next Chapter Button event listeners
     nextBtn.addEventListener('click', nextChapter);
+
+    // Zoom In Button event listener
+    zoomInBtn.addEventListener('click', () => {
+        updateZoom(zoom + 5);
+    });
+
+    // Zoom Out Button event listener
+    zoomOutBtn.addEventListener('click', () => {
+        updateZoom(zoom - 5);
+    });
+
+    // Zoom Reset Button event listener
+    zoomResetBtn.addEventListener('click', () => {
+        updateZoom(100);
+    });
 
     // Keyboard navigation
     document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
This commit enhances the image viewer's zoom functionality based on user feedback.

The following features and fixes have been implemented:
- Added a "Reset Zoom" button to the navigation bar to return the image to its default size.
- Implemented a "pixel-locking" zoom mechanism. When a user zooms, the image's width is set to a fixed pixel value, preventing it from stretching or resizing when the browser window is changed.
- The image's width is only affected by the zoom controls after the initial zoom, not by window resizing.
- The image container will not show a horizontal scrollbar, as per the user's request.