### PR TITLE
feat(viewer): Prevent image resizing on window width change

### DIFF
--- a/viewer.css
+++ b/viewer.css
@@ -17,7 +17,7 @@ html, body {
 }
 
 #image-container img {
-    width: 100%;
+    max-width: 100%; /* Default to image's natural width, but not larger than the container */
     height: auto;
     display: block; /* Remove extra space below images */
 }

--- a/viewer.js
+++ b/viewer.js
@@ -25,13 +25,13 @@ window.addEventListener('DOMContentLoaded', () => {
      */
     function applyZoomToImage(img) {
         if (zoom === 100) {
-            img.style.width = '100%';
+            img.style.width = ''; // Revert to CSS default
             img.style.maxWidth = '100%';
         } else {
             if (lockedBaseWidth) {
                 const newPixelWidth = lockedBaseWidth * (zoom / 100);
                 img.style.width = `${newPixelWidth}px`;
-                img.style.maxWidth = 'none';
+                img.style.maxWidth = 'none'; // Allow image to exceed container width
             }
         }
     }
@@ -48,7 +48,8 @@ window.addEventListener('DOMContentLoaded', () => {
         if (oldZoom === 100 && zoom !== 100) {
             const firstImage = imageContainer.querySelector('img');
             if (firstImage) {
-                lockedBaseWidth = firstImage.clientWidth;
+                // Lock width based on the image's actual size, not its rendered size.
+                lockedBaseWidth = firstImage.naturalWidth;
             }
         }
 
@@ -85,10 +86,9 @@ window.addEventListener('DOMContentLoaded', () => {
             const img = document.createElement('img');
             img.src = imageSrc;
             img.alt = 'Manga Page';
-            img.style.width = '100%';
-            img.style.maxWidth = '100%';
 
             img.onload = () => {
+                // Apply initial zoom state once the image is loaded
                 applyZoomToImage(img);
             };
 


### PR DESCRIPTION
The images in the viewer will no longer resize when the window width changes. The width of the images is now fixed and can only be changed using the zoom tools.

- Modified `viewer.css` to use `max-width: 100%` instead of `width: 100%` for images. This prevents images from stretching to the container width by default.
- Updated `viewer.js` to calculate zoom based on the image's `naturalWidth`, ensuring that zoom is based on the original image size and not the rendered size.
- Adjusted the zoom logic to correctly handle the default zoom level by resetting inline styles, allowing the CSS to control the initial image size.