### PR TITLE
Fix(mangaupdates): Correctly handle errors and data refresh

### DIFF
--- a/cls/manga.cjs
+++ b/cls/manga.cjs
@@ -1992,7 +1992,7 @@ class Manga {
      */
     async addSerieToMangaUpdatesReadingList(hakunekoToMangaUpdatesList) {
         // If the MangaUpdates instance is not available, return
-        if (!this.mangaupdates || !(this.mangaupdates instanceof MangaUpdates)) {
+        if (!this.mangaupdates || !(this.mangaupdates instanceof MangaUpdates) || !this.mangalist) {
             return;
         }
 
@@ -2003,6 +2003,9 @@ class Manga {
         if (!this.db || !(this.db instanceof Low) || !this.mangalist || !(this.mangalist.db instanceof Low)) {
             return;
         }
+
+        // Force a refresh of the MangaUpdates reading list
+        await this.mangalist.getReadingList(true);
 
         // Assign instance db to local variable
         const db = this.db;
@@ -2061,12 +2064,14 @@ class Manga {
                     // Replace with the actual function call and payload as needed
                     /** @type {import('axios').AxiosResponse} */
                     const result = /** @type {import('axios').AxiosResponse} */ (await mangaUpdatesInstance.addListSeries(payload));
-                    if (result.status === 200) {
+                    if (result.status >= 200 && result.status < 300) {
                         console.log(`Added ${payload.length} series to MangaUpdates reading list.`);
                         console.log(result.data);
                         processed = true;
                         // Add the new series to the lookup map to avoid duplicates in the next batch
                         payload.forEach(item => murlLookup.set(item.series.id, item));
+                    } else {
+                        console.error(`Error adding batch to MangaUpdates: Status ${result.status}`, result.data);
                     }
                 } catch (err) {
                     console.error('Error adding batch to MangaUpdates:', err);

--- a/cls/mangaupdates.cjs
+++ b/cls/mangaupdates.cjs
@@ -828,6 +828,10 @@ class MangaUpdates {
         // Step 3: Use the token to call the protected endpoint
         try {
             const response = await axios.post(addListSeriesEndpoint, payload, RequestConfig);
+            if (response.data && response.data.status === 'EXCEPTION') {
+                console.warn('(addListSeries) API Error:', ' [Status]:', response.status, '[Message]', response.data);
+                return { status: 400, data: response.data };
+            }
             responseData = response;
         } catch (error) {
             if (axios.isAxiosError(error)) {
@@ -839,7 +843,7 @@ class MangaUpdates {
                     }
                 );
 
-                return { status: 200, data: error.response?.data };
+                return { status: error.response?.status ?? 500, data: error.response?.data };
             }
             else
                 throw MangaUpdates.formatAxiosError(error, 'addListSeries');


### PR DESCRIPTION
This commit fixes a bug in the `addSerieToMangaUpdatesReadingList` function where failures were not being reported correctly and stale data could cause issues.

- The `addListSeries` function in `cls/mangaupdates.cjs` now propagates the correct HTTP status codes on API errors, instead of masking them with a 200 status. It also handles API-specific exceptions returned in the response body.

- The `addSerieToMangaUpdatesReadingList` function in `cls/manga.cjs` now forces a refresh of the MangaUpdates reading list before processing to ensure the local data is up-to-date. The success check for the API call has been made more robust to correctly identify failed requests.